### PR TITLE
Warn when a resource is detected but not priced (#48)

### DIFF
--- a/cmd/c3x/estimate.go
+++ b/cmd/c3x/estimate.go
@@ -223,14 +223,27 @@ func runEstimate(
 		return err
 	}
 
-	if showSkipped && len(est.Skipped) > 0 {
+	if len(est.Skipped) > 0 {
 		// Print to stderr so machine-readable formats (--format json,
 		// --format csv) on stdout stay parseable.
-		fmt.Fprintf(cmd.ErrOrStderr(),
-			"\n%d resource(s) were detected but not priced:\n", len(est.Skipped))
-		for _, s := range est.Skipped {
-			fmt.Fprintf(cmd.ErrOrStderr(), "  - %s.%s: %s\n",
-				s.Resource.Kind, s.Resource.Name, s.Reason)
+		if showSkipped {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"\n%d resource(s) were detected but not priced:\n", len(est.Skipped))
+			for _, s := range est.Skipped {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  - %s.%s: %s\n",
+					s.Resource.Kind, s.Resource.Name, s.Reason)
+			}
+		} else {
+			// Warn by default: a resource that couldn't be priced must
+			// not be silently dropped, or users assume it's free.
+			verb := "resources were"
+			if len(est.Skipped) == 1 {
+				verb = "resource was"
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"\nwarning: %d %s detected but not priced and excluded from the "+
+					"total; re-run with --show-skipped for details.\n",
+				len(est.Skipped), verb)
 		}
 	}
 

--- a/cmd/c3x/estimate_test.go
+++ b/cmd/c3x/estimate_test.go
@@ -61,6 +61,46 @@ func TestEstimateAgainstRealTerraform(t *testing.T) {
 	}
 }
 
+// TestEstimateWarnsOnUnpricedResource is the regression guard for #48:
+// a resource that is parsed but matches no pricing dimension must be
+// surfaced with a warning by default, not silently dropped from the
+// output (which would let users assume it's free).
+func TestEstimateWarnsOnUnpricedResource(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	// db-n1-standard-1 is a legacy Cloud SQL tier with no catalog
+	// mapping, so every compute dimension guards out and the instance
+	// cannot be priced. The aws_instance keeps the estimate non-empty.
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+		provider "aws" { region = "us-east-1" }
+		resource "aws_instance" "web" {
+		  ami           = "ami-x"
+		  instance_type = "t3.micro"
+		}
+		resource "google_sql_database_instance" "legacy" {
+		  database_version = "POSTGRES_15"
+		  region           = "us-central1"
+		  settings {
+		    tier = "db-n1-standard-1"
+		  }
+		}
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newRootCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"estimate", "--path", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("estimate failed: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "not priced") {
+		t.Errorf("expected an unpriced-resource warning by default, got:\n%s", got)
+	}
+}
+
 // TestEstimateAcceptsVarFlag wires up --var=name=value end-to-end.
 func TestEstimateAcceptsVarFlag(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())


### PR DESCRIPTION
Follow-up to the second point in #48: a resource that is parsed but matches no pricing dimension (e.g. an unmapped tier) was only shown behind `--show-skipped`, so by default it silently vanished from the estimate and users could assume it was free.

## Change
Emit a concise warning to **stderr** by default whenever resources are skipped:

```
warning: 1 resource was detected but not priced and excluded from the total; re-run with --show-skipped for details.
```

Full per-resource detail stays behind `--show-skipped`; stdout stays clean for `--format json/csv`.

Adds a regression test (`TestEstimateWarnsOnUnpricedResource`). Full `cmd` suite + `go vet` pass.

Refs #48