### PR TITLE
feat(plan): estimate the full post-apply fleet from plan JSON (#51)

### DIFF
--- a/cmd/c3x/estimate.go
+++ b/cmd/c3x/estimate.go
@@ -54,6 +54,11 @@ func newEstimateCmd() *cobra.Command {
 supported resource against pricing.c3x.dev, and prints a per-resource
 breakdown.
 
+For a plan JSON input, the estimate covers the full post-apply state —
+every resource that will exist after the plan is applied, the same as
+estimating the .tf — not only the resources this plan changes. --budget
+therefore gates the full projected total.
+
 Variables can be supplied via .tfvars files (auto-loaded from the
 project directory), --var-file flags, or --var name=value pairs. The
 precedence matches Terraform's: defaults < auto.tfvars < --var-file <

--- a/internal/parser/plan/plan.go
+++ b/internal/parser/plan/plan.go
@@ -15,8 +15,10 @@ import (
 )
 
 // ParseFile reads a plan.json file and returns the resources it
-// describes. Resources scheduled only for `delete` or `no-op` are
-// filtered out — the calculator should price the post-apply state.
+// describes. The estimate reflects the post-apply state: every resource
+// that will exist after the plan is applied, priced as a whole (the same
+// meaning as estimating the .tf), not just the resources this plan
+// changes. Use `--show-delta` / `c3x diff` for the change-only view.
 func ParseFile(path string, logger *slog.Logger) ([]domain.Resource, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -27,6 +29,13 @@ func ParseFile(path string, logger *slog.Logger) ([]domain.Resource, error) {
 
 // ParseBytes parses an in-memory plan JSON document. Exported so tests
 // and pipes can drive the parser without a temp file.
+//
+// The resource set comes from planned_values (the complete post-apply
+// state) so unchanged resources are priced too — a plan where nothing
+// changes still reports the full cost of the infrastructure it
+// describes. Older plan formats that omit planned_values fall back to
+// resource_changes, excluding resources scheduled purely for destruction
+// (they won't exist post-apply).
 func ParseBytes(raw []byte, logger *slog.Logger) ([]domain.Resource, error) {
 	if logger == nil {
 		logger = slog.Default()
@@ -37,26 +46,61 @@ func ParseBytes(raw []byte, logger *slog.Logger) ([]domain.Resource, error) {
 	}
 
 	region := defaultRegion(doc.Configuration)
-
 	out := make([]domain.Resource, 0, len(doc.ResourceChanges))
-	for _, rc := range doc.ResourceChanges {
-		if shouldSkip(rc.Change.Actions) {
+
+	// Primary: planned_values is the full desired (post-apply) state.
+	if doc.PlannedValues != nil {
+		collectPlanned(doc.PlannedValues.RootModule, region, &out)
+	}
+
+	// Fallback for plan formats that omit planned_values.
+	if len(out) == 0 {
+		for _, rc := range doc.ResourceChanges {
+			if isDeleteOnly(rc.Change.Actions) {
+				continue
+			}
+			attrs, _ := rc.Change.After.(map[string]any)
+			r := domain.Resource{
+				Ref:        domain.Reference{Kind: rc.Type, Name: nameFromAddress(rc.Address, rc.Name)},
+				Attributes: attrs,
+			}
+			if region != "" {
+				rgn := region
+				r.Region = &rgn
+			}
+			out = append(out, r)
+		}
+	}
+
+	logger.Debug("plan parsed", "resources", len(out), "region", region)
+	return out, nil
+}
+
+// collectPlanned walks a planned_values module tree, appending every
+// managed resource. Data sources and null child-module entries (which
+// untrusted plan JSON can contain) are skipped rather than dereferenced.
+func collectPlanned(mod *plannedModule, region string, out *[]domain.Resource) {
+	if mod == nil {
+		return
+	}
+	for _, pr := range mod.Resources {
+		if pr.Mode != "managed" {
 			continue
 		}
-		attrs, _ := rc.Change.After.(map[string]any)
-		ref := domain.Reference{Kind: rc.Type, Name: nameFromAddress(rc.Address, rc.Name)}
+		attrs, _ := pr.Values.(map[string]any)
 		r := domain.Resource{
-			Ref:        ref,
+			Ref:        domain.Reference{Kind: pr.Type, Name: nameFromAddress(pr.Address, pr.Name)},
 			Attributes: attrs,
 		}
 		if region != "" {
 			rgn := region
 			r.Region = &rgn
 		}
-		out = append(out, r)
+		*out = append(*out, r)
 	}
-	logger.Debug("plan parsed", "resources", len(out), "region", region)
-	return out, nil
+	for _, child := range mod.ChildModules {
+		collectPlanned(child, region, out)
+	}
 }
 
 // nameFromAddress reconstructs the resource name preserving any
@@ -85,12 +129,15 @@ func nameFromAddress(address, fallback string) string {
 	return parts[len(parts)-1]
 }
 
-func shouldSkip(actions []string) bool {
+// isDeleteOnly reports whether a resource_changes entry is scheduled
+// purely for destruction, so it won't exist post-apply. Replaces
+// (delete+create) and no-op resources are kept.
+func isDeleteOnly(actions []string) bool {
 	if len(actions) == 0 {
 		return false
 	}
 	for _, a := range actions {
-		if a != "delete" && a != "no-op" {
+		if a != "delete" {
 			return false
 		}
 	}
@@ -131,8 +178,27 @@ func defaultRegion(cfg *configuration) string {
 // planFile mirrors the fields we care about from `terraform show -json`.
 // Anything not declared here is ignored at decode time.
 type planFile struct {
+	PlannedValues   *plannedValues   `json:"planned_values"`
 	ResourceChanges []resourceChange `json:"resource_changes"`
 	Configuration   *configuration   `json:"configuration"`
+}
+
+// plannedValues is the projected post-apply state.
+type plannedValues struct {
+	RootModule *plannedModule `json:"root_module"`
+}
+
+type plannedModule struct {
+	Resources    []plannedResource `json:"resources"`
+	ChildModules []*plannedModule  `json:"child_modules"`
+}
+
+type plannedResource struct {
+	Address string `json:"address"`
+	Mode    string `json:"mode"`
+	Type    string `json:"type"`
+	Name    string `json:"name"`
+	Values  any    `json:"values"`
 }
 
 type resourceChange struct {

--- a/internal/parser/plan/plan_test.go
+++ b/internal/parser/plan/plan_test.go
@@ -127,3 +127,90 @@ func TestRejectsInvalidJson(t *testing.T) {
 		t.Errorf("error message lacks context: %v", err)
 	}
 }
+
+// TestPlannedValues_IncludesUnchangedResources is the core of the
+// full-fleet decision (#51): estimating a plan prices every resource in
+// the post-apply state, including unchanged (no-op) ones, not just the
+// ones this plan changes.
+func TestPlannedValues_IncludesUnchangedResources(t *testing.T) {
+	t.Parallel()
+	raw := `{
+		"resource_changes": [
+			{ "address": "aws_instance.new", "type": "aws_instance", "name": "new",
+			  "change": { "actions": ["create"] } },
+			{ "address": "aws_instance.existing", "type": "aws_instance", "name": "existing",
+			  "change": { "actions": ["no-op"] } }
+		],
+		"planned_values": {
+			"root_module": {
+				"resources": [
+					{ "address": "aws_instance.new", "mode": "managed", "type": "aws_instance", "name": "new", "values": { "instance_type": "t3.micro" } },
+					{ "address": "aws_instance.existing", "mode": "managed", "type": "aws_instance", "name": "existing", "values": { "instance_type": "t3.large" } }
+				]
+			}
+		}
+	}`
+	got, err := plan.ParseBytes([]byte(raw), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 resources (unchanged included), got %d", len(got))
+	}
+}
+
+// TestPlannedValues_WalksChildModulesSafely covers the module tree walk:
+// child modules are recursed, data sources are skipped, and a null
+// child_modules element (untrusted plan JSON) does not panic.
+func TestPlannedValues_WalksChildModulesSafely(t *testing.T) {
+	t.Parallel()
+	raw := `{
+		"planned_values": {
+			"root_module": {
+				"resources": [
+					{ "address": "data.aws_ami.x", "mode": "data", "type": "aws_ami", "name": "x", "values": {} }
+				],
+				"child_modules": [
+					null,
+					{ "address": "module.db",
+					  "resources": [ { "address": "module.db.aws_db_instance.main", "mode": "managed", "type": "aws_db_instance", "name": "main", "values": { "instance_class": "db.t3.micro" } } ] }
+				]
+			}
+		}
+	}`
+	got, err := plan.ParseBytes([]byte(raw), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 managed resource (data + null child skipped), got %d", len(got))
+	}
+	if got[0].Ref.Kind != "aws_db_instance" {
+		t.Errorf("expected the child-module db instance, got %s", got[0].Ref.Kind)
+	}
+}
+
+// TestFallback_KeepsNoOpExcludesDeleteOnly checks the older-format path
+// (no planned_values): unchanged resources are kept (they exist
+// post-apply); resources scheduled only for destruction are dropped.
+func TestFallback_KeepsNoOpExcludesDeleteOnly(t *testing.T) {
+	t.Parallel()
+	raw := `{
+		"resource_changes": [
+			{ "address": "aws_instance.keep", "type": "aws_instance", "name": "keep",
+			  "change": { "actions": ["no-op"], "after": { "instance_type": "t3.micro" } } },
+			{ "address": "aws_instance.gone", "type": "aws_instance", "name": "gone",
+			  "change": { "actions": ["delete"], "after": null } }
+		]
+	}`
+	got, err := plan.ParseBytes([]byte(raw), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource (no-op kept, delete excluded), got %d", len(got))
+	}
+	if got[0].Ref.Name != "keep" {
+		t.Errorf("expected the no-op resource, got %s", got[0].Ref.Name)
+	}
+}


### PR DESCRIPTION
Implements the decision from #51.

## Decision
`c3x estimate <plan.json>` now prices the **full post-apply fleet** (walk `planned_values`), not just the resources the plan changes — the same meaning as estimating the `.tf`. This fixes the near-zero total for plans where most resources are unchanged.

## What changed
- Parser walks `planned_values` (the complete post-apply state); data sources and null `child_modules` entries are skipped, not dereferenced.
- Fallback to `resource_changes` for older plan formats, now **keeping** no-op resources and excluding **delete-only** ones (post-apply semantics).
- Help text notes the plan semantics and that `--budget` gates the full projected total.

## Behavior change (called out for release notes)
`estimate <plan.json>` and `--format json` from a plan now report the full total. `--budget` therefore gates the whole fleet. The change-only view remains available via `c3x diff` (and the upcoming `--show-delta`).

## Tests
New: unchanged-included, child-module walk with null-guard + data-source skip, fallback keeps-no-op/excludes-delete. Full suite + `go vet` pass. Verified end-to-end: a plan with a no-op + a create now prices both.

Thanks to @Tyron2k, whose #46 surfaced this; that PR can now rescope to the `--show-delta` view and `optional()` defaults on top of this consistent base.

Resolves #51.
